### PR TITLE
fix: ensure gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@
 !*.*
 ac-library
 
+.ccls-cache/
+.DS_Store
+


### PR DESCRIPTION
global gitignoreに指定していたけど、!\*.\*と!\*/ ですべて解除されてることに気が付きました